### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Active-Token-Lighting
 
+### 0.2.0 Update
+This is a large update that fundamentally changes the backend framework of the module. Your current ATL effects will not be changed in function, but you will get warnings to change to the new syntax. This will be slowly phased out over updates. Any ATL flag will now adjust a linked actor Prototype Token to match the data, these will carry between scenes as they should. The `lightEffect` key has been changed to `lightAnimation` any previous `lightEffect` flags will not work and need to be updated immediately. 
 
 Active Token Lighting will dynamically adjust token light settings based on active effects present on the actor. 
-You can use the syntax `flags.ATL.lighting.X` as the attribute key. 
+You can use the syntax `ATL.X` as the attribute key. 
 X can be:
 - dimLight
 - brightLight
@@ -12,27 +14,20 @@ X can be:
 - lightColor
 - colorIntensity
 - lightAngle
-- lightEffect (for this enter an object as the value, eg. `{"type":"torch","speed":1,"intensity":1}` )
+- lightAnimation (for this enter an object as the value, eg. `{"type":"torch","speed":1,"intensity":1}` )
 
-To adjust token size you can use `flags.ATL.size.X` where X can be:
+To adjust token size you can use `ATL.Y` where X can be:
 - height
 - width
 - scale
 
-There are 3 preset values for torch, lantern and candle. Use `flags.ATL.lighting.preset` and value of the name in lowercase `torch`, `lantern`, `candle`. These will override custom values set in other flags.
+There are 3 preset values for torch, lantern and candle. Use `ATL.preset` and value of the name in lowercase `torch`, `lantern`, `candle`. These will override custom values set in other flags.
 
 Works very well alongside DAE for equip-toggle effects (Goggles of Night for example) or with Midi QoL for consumables (like torches)
 
-![Torch config](https://github.com/kandashi/Active-Token-Lighting/blob/main/Images/Torch%20config.PNG)
-![Goggles of Night config](https://github.com/kandashi/Active-Token-Lighting/blob/main/Images/Goggles%20of%20Night%20config.PNG)
-![Active Lighting](https://github.com/kandashi/Active-Token-Lighting/blob/main/Images/Active%20Token%20Lighting%20Demo.gif?raw=true)
 
 ## Modes
-- Add will only add onto a current existing ATL flag, not onto the existing actor vision
-- Upgrade will do as expected
-- Override will only override other ATL flags, not the actor default
-- Custom and Multiply do not work
-
+Modes will act the same as standard active effects
 
 ## Presets
 - 3 preset values 
@@ -40,7 +35,7 @@ Works very well alongside DAE for equip-toggle effects (Goggles of Night for exa
             dimLight = "40";
             brightLight = "20";
             lightColor = "#a2642a";
-            lightEffect = {
+            lightAnimation = {
                 'type': 'torch',
                 'speed': 1,
                 'intensity': 1
@@ -51,7 +46,7 @@ Works very well alongside DAE for equip-toggle effects (Goggles of Night for exa
             dimLight = "60";
             brightLight = "30";
             lightColor = "#a2642a";
-            lightEffect = {
+            lightAnimation = {
                 'type': 'torch',
                 'speed': 1,
                 'intensity': 1
@@ -62,7 +57,7 @@ Works very well alongside DAE for equip-toggle effects (Goggles of Night for exa
             dimLight = "10";
             brightLight = "2";
             lightColor = "#a2642a";
-            lightEffect = {
+            lightAnimation = {
                 'type': 'torch',
                 'speed': 1,
                 'intensity': 1

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"title": "Active Token Lighting",
 	"description": "Active Token Lighting",
 	"author": "Kandashi",
-	"version": "0.1.18",
+	"version": "0.2.0",
 	"minimumCoreVersion": "0.7.5",
 	"compatibleCoreVersion": "0.7.9",
 	"scripts": [

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -1,3 +1,4 @@
+
 class ATL {
 
     static init() {
@@ -7,7 +8,7 @@ class ATL {
                 dimLight: "40",
                 brightLight: "20",
                 lightColor: "#a2642a",
-                lightEffect: {
+                lightAnimation: {
                     'type': 'torch',
                     'speed': 1,
                     'intensity': 1
@@ -20,7 +21,7 @@ class ATL {
                 dimLight: "60",
                 brightLight: "30",
                 lightColor: "#a2642a",
-                lightEffect: {
+                lightAnimation: {
                     'type': 'torch',
                     'speed': 1,
                     'intensity': 1
@@ -34,7 +35,7 @@ class ATL {
                 dimLight: "10",
                 brightLight: "2",
                 lightColor: "#a2642a",
-                lightEffect: {
+                lightAnimation: {
                     'type': 'torch',
                     'speed': 1,
                     'intensity': 1
@@ -59,145 +60,41 @@ class ATL {
             config: false,
             default: defaultPresets,
             type: Object,
-        })
+        });
+        game.settings.register("ATL", "conversion", {
+            name: "conversion level",
+            scope: "world",
+            config: false,
+            default: "0",
+            type: String,
+        });
     }
     static ready() {
 
         Hooks.on("updateActiveEffect", async (entity, effect, options) => {
-            if (entity.data.type === "character") {
-                let ATLUpdate = false;
-                for (let change of effect.changes) {
-                    if (change.key.includes("ATL")) ATLUpdate = true
-                }
-                if (ATLUpdate === false) return;
-                ATL.ReadUpdate(entity.id, effect)
-            }
+            let ATLeffects = entity.effects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
+            if (ATLeffects) ATL.applyEffects(entity, ATLeffects)
         })
 
-        Hooks.on("createActiveEffect", async (actor, effect, options) => {
-            let ATLUpdate = false;
-            for (let change of effect.changes) {
-                if (change.key.includes("ATL")) ATLUpdate = true
-            }
-            if (ATLUpdate === false) return;
-            ATL.ReadUpdate(actor.id, effect)
+        Hooks.on("createActiveEffect", async (entity, effect, options) => {
+            let ATLeffects = entity.effects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
+            if (ATLeffects) ATL.applyEffects(entity, ATLeffects)
         })
 
-        Hooks.on("deleteActiveEffect", async (actor, effect, options) => {
-            let ATLUpdate = false;
-            for (let change of effect.changes) {
-                if (change.key.includes("ATL")) ATLUpdate = true
-            }
-            if (ATLUpdate === false) return;
-            ATL.ReadUpdate(actor.id, effect)
+        Hooks.on("deleteActiveEffect", async (entity, effect, options) => {
+            let ATLeffects = entity.effects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
+            if (ATLeffects) ATL.applyEffects(entity, ATLeffects)
         })
 
-        Hooks.on("preUpdateToken", (scene, token, update) => {
+        Hooks.on("updateToken", (scene, token, update) => {
             if (!(update.actorData?.effects)) return
-            let removed = token.actorData?.effects?.filter(x => !update.actorData?.effects?.includes(x));
-            let added = update.actorData?.effects?.filter(x => !token.actorData?.effects?.includes(x));
-            let effects = []
-            if (added) added.forEach(i => effects.push(i))
-            if (removed) removed.forEach(i => effects.push(i))
-            let ATLUpdate = false;
-            for (let testEffect of effects) {
-                for (let change of testEffect.changes) {
-                    if (change.key.includes("ATL")) {
-                        ATLUpdate = true;
-                        break;
-                    }
-                }
-            }
-
-            if (ATLUpdate === false) return;
-            ATL.ReadUpdateUnlinked(token._id)
+            let entity = canvas.tokens.get(token._id).actor
+            let ATLeffects = entity.effects.filter(e => !!e.data.changes.find(effect => effect.key.includes("ATL")))
+            ATL.applyEffects(entity, ATLeffects)
         })
     }
 
 
-    static ATLMap = new Map()
-
-    static ReadUpdate(actorId, effect) {
-        let gm = game.user === game.users.find((u) => u.isGM && u.active)
-        if (!gm) return;
-        setTimeout(() => {
-            let actor = game.actors.get(actorId)
-            const LightFlag = actor.getFlag('ATL', 'lighting')
-            const SizeFlag = actor.getFlag('ATL', 'size')
-
-            let token = actor.getActiveTokens()[0];
-            ATL.performUpdate(token, LightFlag, SizeFlag, actor.data.token)
-        }, 20)
-    }
-
-
-
-    static ReadUpdateUnlinked(tokenId) {
-        let gm = game.user === game.users.find((u) => u.isGM && u.active)
-        if (!gm) return;
-        let ATLHookId = Hooks.on("updateToken", (scene, token1, update) => {
-            if (token1._id !== tokenId) return;
-            let token = canvas.tokens.get(tokenId);
-            let actor = token.actor;
-            let tokenData = actor.data.token;
-            const LightFlag = actor.getFlag('ATL', 'lighting')
-            const SizeFlag = actor.getFlag('ATL', 'size')
-
-
-            ATL.performUpdate(token, LightFlag, SizeFlag, tokenData)
-            Hooks.off("updateToken", ATLHookId)
-        })
-    }
-
-    static performUpdate(token, LightFlag, SizeFlag, tokenData) {
-
-
-
-        if (LightFlag?.preset) {
-            let presetArray = game.settings.get("ATL", "presets")
-            let preset = presetArray.find(i => i.name === LightFlag.preset)
-            var { dimLight, brightLight, dimSight, brightSight, sightAngle, lightColor, lightEffect, colorIntensity, lightAngle } = preset;
-        }
-        else var { dimLight, brightLight, dimSight, brightSight, sightAngle, lightColor, lightEffect, colorIntensity, lightAngle } = LightFlag !== undefined ? LightFlag : 0;
-
-
-        if (lightAngle) lightAngle = parseInt(lightAngle);
-        if (sightAngle) sightAngle = parseInt(sightAngle);
-
-        if (dimLight === undefined) dimLight = 0;
-        if (brightLight === undefined) brightLight = 0
-        if (dimSight === undefined) dimSight = 0
-        if (brightSight === undefined) brightSight = 0
-        if (sightAngle === undefined) sightAngle = 360
-        if (lightColor === undefined) lightColor = ""
-        if (lightAngle === undefined) lightAngle = 360
-        if (colorIntensity === undefined) colorIntensity = tokenData.lightAlpha
-
-
-        let { height, width, scale } = SizeFlag !== undefined ? SizeFlag : 0;
-        if (height === undefined) height = tokenData.height;
-        if (width === undefined) width = tokenData.width;
-        if (scale === undefined) scale = tokenData.scale;
-
-
-
-        let newDimLight = tokenData.dimLight > dimLight ? tokenData.dimLight : dimLight;
-        let newBrightLight = tokenData.brightLight > brightLight ? tokenData.brightLight : brightLight;
-        let newDimSight = tokenData.dimSight > dimSight ? tokenData.dimSight : dimSight;
-        let newBrightSight = tokenData.brightSight > brightSight ? tokenData.brightSight : brightSight;
-        let newSightAngle = tokenData.sightAngle > sightAngle ? sightAngle : tokenData.sightAngle;
-        let lightAnimation;
-
-        if (lightEffect === undefined || lightEffect === "") lightAnimation = tokenData.lightAnimation
-        else if (LightFlag?.preset) lightAnimation = lightEffect;
-        else lightAnimation = JSON.parse(lightEffect)
-
-        if (game.settings.get("ATL", "size") === true)
-            token.update({ "lightAnimation": lightAnimation, dimLight: newDimLight, brightLight: newBrightLight, dimSight: newDimSight, brightSight: newBrightSight, lightColor: lightColor, sightAngle: newSightAngle, lightAlpha: (colorIntensity * colorIntensity), height: height, width: width, scale: scale, lightAngle: lightAngle })
-        else if (game.settings.get("ATL", "size") === false)
-            token.update({ "lightAnimation": lightAnimation, dimLight: newDimLight, brightLight: newBrightLight, dimSight: newDimSight, brightSight: newBrightSight, lightColor: lightColor, sightAngle: newSightAngle, lightAlpha: (colorIntensity * colorIntensity), lightAngle: lightAngle })
-
-    }
 
     static AddPreset(name, object) {
         if (!name) {
@@ -257,7 +154,7 @@ class ATL {
 
     static GeneratePreset(preset, copy) {
 
-        let { dimLight, brightLight, dimSight, brightSight, sightAngle, lightColor, lightEffect, colorIntensity, lightAngle, name } = preset ? preset : 0
+        let { dimLight, brightLight, dimSight, brightSight, sightAngle, lightColor, lightEffect: lightAnimation, colorIntensity, lightAngle, name } = preset ? preset : 0
         switch (copy) {
             case true: name = `${name} (copy)`;
                 break;
@@ -273,44 +170,44 @@ class ATL {
         if (lightColor === undefined) lightColor = "#FFFFFF"
         if (lightAngle === undefined) lightAngle = 360
         if (colorIntensity === undefined) colorIntensity = 1
-        if (lightEffect === undefined) lightEffect = {}
+        if (lightAnimation === undefined) lightAnimation = {}
 
 
         let lightTypes = `<option selected value="none"> None</option>
-        <option value="torch" ${lightEffect.type === "torch" ? 'selected' : ''}> Torch</option>
-        <option value="pulse" ${lightEffect.type === "pulse" ? 'selected' : ''}> Pulse</option>
-        <option value="chroma" ${lightEffect.type === "chroma" ? 'selected' : ''}> Chroma</option>
-        <option value="wave" ${lightEffect.type === "wave" ? 'selected' : ''}> Pulsing Wave</option>
-        <option value="fog" ${lightEffect.type === "fog" ? 'selected' : ''}> Swirling Fog</option>
-        <option value="sunburst" ${lightEffect.type === "sunburst" ? 'selected' : ''}> Sunburst</option>
-        <option value="dome" ${lightEffect.type === "dome" ? 'selected' : ''}> Light Dome</option>
-        <option value="emanation" ${lightEffect.type === "emanation" ? 'selected' : ''}> Mysterious Emanation</option>
-        <option value="hexa" ${lightEffect.type === "hexa" ? 'selected' : ''}>  Hexa Dome</option>
-        <option value="ghost" ${lightEffect.type === "ghost" ? 'selected' : ''}> Ghostly Light</option>
-        <option value="energy" ${lightEffect.type === "energy" ? 'selected' : ''}> Energy Field</option>
-        <option value="roiling" ${lightEffect.type === "roiling" ? 'selected' : ''}> Roiling Mass (Darkness)</option>
-        <option value="hole" ${lightEffect.type === "hole" ? 'selected' : ''}> Black Hole (Darkness)</option>`
+        <option value="torch" ${lightAnimation.type === "torch" ? 'selected' : ''}> Torch</option>
+        <option value="pulse" ${lightAnimation.type === "pulse" ? 'selected' : ''}> Pulse</option>
+        <option value="chroma" ${lightAnimation.type === "chroma" ? 'selected' : ''}> Chroma</option>
+        <option value="wave" ${lightAnimation.type === "wave" ? 'selected' : ''}> Pulsing Wave</option>
+        <option value="fog" ${lightAnimation.type === "fog" ? 'selected' : ''}> Swirling Fog</option>
+        <option value="sunburst" ${lightAnimation.type === "sunburst" ? 'selected' : ''}> Sunburst</option>
+        <option value="dome" ${lightAnimation.type === "dome" ? 'selected' : ''}> Light Dome</option>
+        <option value="emanation" ${lightAnimation.type === "emanation" ? 'selected' : ''}> Mysterious Emanation</option>
+        <option value="hexa" ${lightAnimation.type === "hexa" ? 'selected' : ''}>  Hexa Dome</option>
+        <option value="ghost" ${lightAnimation.type === "ghost" ? 'selected' : ''}> Ghostly Light</option>
+        <option value="energy" ${lightAnimation.type === "energy" ? 'selected' : ''}> Energy Field</option>
+        <option value="roiling" ${lightAnimation.type === "roiling" ? 'selected' : ''}> Roiling Mass (Darkness)</option>
+        <option value="hole" ${lightAnimation.type === "hole" ? 'selected' : ''}> Black Hole (Darkness)</option>`
 
 
-        if(game.modules.get("CommunityLighting").active){
+        if (game.modules.get("CommunityLighting").active) {
             lightTypes += `
             <optgroup label= "Blitz" id="animationType">
-            <option value="BlitzFader" ${lightEffect.type === "BlitzFader" ? 'selected' : ''}>Fader</option>
-            <option value="BlitzLightning" ${lightEffect.type === "BlitzLightning" ? 'selected' : ''}>Lightning (expirmental)</option>
-            <option value="BlitzElectric Fault" ${lightEffect.type === "BlitzElectric Fault" ? 'selected' : ''}>Electrical Fault</option>
-            <option value="BlitzSimple Flash" ${lightEffect.type === "BlitzSimple Flash" ? 'selected' : ''}>Simple Flash</option>
-            <option value="BlitzRBG Flash" ${lightEffect.type === "BlitzRBG Flash" ? 'selected' : ''}>RGB Flash</option>
-            <option value="BlitzPolice Flash" ${lightEffect.type === "BlitzPolice Flash" ? 'selected' : ''}>Police Flash</option>
-            <option value="BlitzStatic Blur" ${lightEffect.type === "BlitzStatic Blur" ? 'selected' : ''}> Static Blur</option>
-            <option value="BlitzAlternate Torch" ${lightEffect.type === "BlitzAlternate Torch" ? 'selected' : ''}>Alternate Torch</option>
-            <option value="BlitzBlurred Torch" ${lightEffect.type === "BlitzBlurred Torch" ? 'selected' : ''}>Blurred Torch</option>
-            <option value="BlitzGrid Force-Field Colorshift" ${lightEffect.type === "BlitzGrid Force-Field Colorshift" ? 'selected' : ''}>Grid Force-Field Colorshift</option>
+            <option value="BlitzFader" ${lightAnimation.type === "BlitzFader" ? 'selected' : ''}>Fader</option>
+            <option value="BlitzLightning" ${lightAnimation.type === "BlitzLightning" ? 'selected' : ''}>Lightning (expirmental)</option>
+            <option value="BlitzElectric Fault" ${lightAnimation.type === "BlitzElectric Fault" ? 'selected' : ''}>Electrical Fault</option>
+            <option value="BlitzSimple Flash" ${lightAnimation.type === "BlitzSimple Flash" ? 'selected' : ''}>Simple Flash</option>
+            <option value="BlitzRBG Flash" ${lightAnimation.type === "BlitzRBG Flash" ? 'selected' : ''}>RGB Flash</option>
+            <option value="BlitzPolice Flash" ${lightAnimation.type === "BlitzPolice Flash" ? 'selected' : ''}>Police Flash</option>
+            <option value="BlitzStatic Blur" ${lightAnimation.type === "BlitzStatic Blur" ? 'selected' : ''}> Static Blur</option>
+            <option value="BlitzAlternate Torch" ${lightAnimation.type === "BlitzAlternate Torch" ? 'selected' : ''}>Alternate Torch</option>
+            <option value="BlitzBlurred Torch" ${lightAnimation.type === "BlitzBlurred Torch" ? 'selected' : ''}>Blurred Torch</option>
+            <option value="BlitzGrid Force-Field Colorshift" ${lightAnimation.type === "BlitzGrid Force-Field Colorshift" ? 'selected' : ''}>Grid Force-Field Colorshift</option>
             </optgroup>
             <optgroup label="SecretFire" id="animationType">
-            <option value="SecretFireGrid Force-Field" ${lightEffect.type === "SecretFireGrid Force-Field" ? 'selected' : ''}>Grid Force-Field</option>
-            <option value="SecretFireSmoke Patch" ${lightEffect.type === "SecretFireSmoke Patch" ? 'selected' : ''}>Smoke Patch</option>
-            <option value="SecretFireStar Light" ${lightEffect.type === "SecretFireStar Light" ? 'selected' : ''}>Star Light</option>
-            <option value="SecretFireStar Light Disco" ${lightEffect.type === "SecretFireStar Light Disco" ? 'selected' : ''}>Star Light Disco</option>
+            <option value="SecretFireGrid Force-Field" ${lightAnimation.type === "SecretFireGrid Force-Field" ? 'selected' : ''}>Grid Force-Field</option>
+            <option value="SecretFireSmoke Patch" ${lightAnimation.type === "SecretFireSmoke Patch" ? 'selected' : ''}>Smoke Patch</option>
+            <option value="SecretFireStar Light" ${lightAnimation.type === "SecretFireStar Light" ? 'selected' : ''}>Star Light</option>
+            <option value="SecretFireStar Light Disco" ${lightAnimation.type === "SecretFireStar Light Disco" ? 'selected' : ''}>Star Light Disco</option>
             </optgroup>
         `
         }
@@ -341,11 +238,11 @@ class ATL {
             </div>
             <div class="form-group" clear: both; display: flex; flex-direction: row; flex-wrap: wrap;margin: 3px 0;align-items: center;">
                     <label for="lightAngle"> Light Angle: </label>
-                    <input id="lightAngle" name="lightAngle" type="range" min="0" max="360" step="1" value="${lightAngle}"></input>
+                    <input id="lightAngle" name="lightAngle" type="number" min="0" max="360" step="1" value="${lightAngle}"></input>
             </div>
             <div class="form-group" clear: both; display: flex; flex-direction: row; flex-wrap: wrap;margin: 3px 0;align-items: center;">
                     <label for="sightAngle"> Sight Angle: </label>
-                    <input id="sightAngle" name="sightAngle" type="range" min="0" max="360" step="1" value="${sightAngle}"></input>
+                    <input id="sightAngle" name="sightAngle" type="number" min="0" max="360" step="1" value="${sightAngle}"></input>
             </div>
             <div class="form-group" clear: both; display: flex; flex-direction: row; flex-wrap: wrap;margin: 3px 0;align-items: center;">
                 <label for="lightAlpha"> Light Intensity: </label>
@@ -363,15 +260,15 @@ class ATL {
             </div>
             <div class="form-group" clear: both; display: flex; flex-direction: row; flex-wrap: wrap;margin: 3px 0;align-items: center;">
                     <label for="animationSpeed"> Animation Speed: </label>
-                    <input id="animationSpeed" name="animationSpeed" type="range" min="1" max="10" step="1" value="${lightEffect?.speed}"></input>
+                    <input id="animationSpeed" name="animationSpeed" type="range" min="1" max="10" step="1" value="${lightAnimation?.speed}"></input>
             </div>
             <div class="form-group" clear: both; display: flex; flex-direction: row; flex-wrap: wrap;margin: 3px 0;align-items: center;">
                     <label for="animationIntensity"> Animation Intensity: </label>
-                    <input id="animationIntensity" name="animationIntensity" type="range" min="1" max="10" step="1" value="${lightEffect?.intensity}"></input>
+                    <input id="animationIntensity" name="animationIntensity" type="range" min="1" max="10" step="1" value="${lightAnimation?.intensity}"></input>
             </div>
                 `;
-        
-                
+
+
         new Dialog({
             title: "ATL Light Editor",
             content: dialogContent,
@@ -399,7 +296,7 @@ class ATL {
                             dimLight: dimLight,
                             brightLight: brightLight,
                             lightColor: lightColor,
-                            lightEffect: {
+                            lightAnimation: {
                                 'type': animationType,
                                 'speed': animationSpeed,
                                 'intensity': animationIntensity
@@ -407,8 +304,8 @@ class ATL {
                             colorIntensity: lightAlpha,
                             dimSight: dimSight,
                             brightSight: brightSight,
-                            sightAngle: sightAngle,
-                            lightAngle: lightAngle,
+                            sightAngle: parseInt(sightAngle),
+                            lightAngle: parseInt(lightAngle),
                             id: id
                         }
                         ATL.AddPreset(name, object)
@@ -506,10 +403,162 @@ class ATL {
             });
         }
     }
+     static async applyEffects(entity, effects) {
+        let tokenArray = entity.getActiveTokens()
+        let overrides = {};
+        const originals = await entity.getFlag("ATL", "originals") || {};
+
+        // Organize non-disabled effects by their application priority
+        const changes = effects.reduce((changes, e) => {
+            if (e.data.disabled) return changes;
+            return changes.concat(e.data.changes.map(c => {
+                c = duplicate(c);
+                c.effect = e;
+                c.priority = c.priority ?? (c.mode * 10);
+                return c;
+            }));
+        }, []);
+        changes.sort((a, b) => a.priority - b.priority);
+
+        // Apply all changes
+        for (let change of changes) {
+            let updateKey = change.key.slice(4)
+            if (updateKey === "preset") {
+                let presetArray = game.settings.get("ATL", "presets")
+                let preset = presetArray.find(i => i.name === change.value)
+                overrides = duplicate(preset);
+                delete overrides.id
+                delete overrides.name
+                overrides.lightAlpha = overrides.colorIntensity * overrides.colorIntensity
+                delete overrides.colorIntensity
+                overrides.lightAngle = parseInt(overrides.lightAngle)
+                overrides.sightAngle = parseInt(overrides.sightAngle)
+                for (const [key, value] of Object.entries(overrides)) {
+                    let ot = typeof getProperty(originals, key)
+                    if (ot === "null" || ot === "undefined") originals[key] = token.data[key]
+                }
+            }
+            else {
+                let preValue = overrides[updateKey] ? overrides[updateKey] : originals[updateKey] || null;
+                const result = ATL.apply(entity, change, originals, preValue);
+                if (result !== null) {
+                    overrides[updateKey] = result;
+                    let ot = typeof getProperty(originals, updateKey)
+                    if (ot === "null" || ot === "undefined") originals[updateKey] = entity.data.token[updateKey]
+                }
+            }
+        }
+
+        if (changes.length < 1) overrides = originals
+        // Expand the set of final overrides
+        for (let eachToken of tokenArray) {
+            await eachToken.update(overrides)
+        }
+        //update actor token
+        let updatedToken = Object.assign(entity.data.token, overrides)
+        await entity.setFlag("ATL", "originals", originals)
+        await entity.update({ token: updatedToken })
+    }
+
+
+    static apply(token, change, originals, preValue) {
+        const modes = CONST.ACTIVE_EFFECT_MODES;
+        switch (change.mode) {
+            case modes.CUSTOM:
+                return ATL.applyCustom(token, change, originals, preValue);
+            case modes.ADD:
+                return ATL.applyAdd(token, change, originals, preValue);
+            case modes.MULTIPLY:
+                return ATL.applyMultiply(token, change, originals, preValue);
+            case modes.OVERRIDE:
+            case modes.UPGRADE:
+            case modes.DOWNGRADE:
+                return ATL.applyOverride(token, change, originals, preValue);
+        }
+    }
+
+    static applyAdd(token, change, originals, current) {
+        let { key, value } = change;
+        key = key.slice(4)
+        //const current = typeof getProperty(originals, key) === "number" ? getProperty(originals, key) : getProperty(token.data, key) || null;
+        const ct = getType(current);
+        let update = null;
+
+        // Handle different types of the current data
+        switch (ct) {
+            case "null":
+                update = parseInt(value);
+                break;
+            case "string":
+                update = current + String(value);
+                break;
+            case "number":
+                if (Number.isNumeric(value)) update = current + Number(value);
+                break;
+            case "Array":
+                if (!current.length || (getType(value) === getType(current[0]))) update = current.concat([value]);
+        }
+        return update;
+    }
+
+    static applyMultiply(token, change, originals, current) {
+        let { key, value } = change;
+        key = key.slice(4)
+        //const current = typeof getProperty(originals, key) === "number" ? getProperty(originals, key) : getProperty(token.data, key) || null;
+        if ((typeof (current) !== "number") || (typeof (value) !== "number")) return null;
+        const update = current * value;
+        return update;
+    }
+
+    static applyOverride(token, change, originals, current) {
+        let { key, value, mode } = change;
+        key = key.slice(4)
+        //const current = typeof getProperty(originals, key) === "number" ? getProperty(originals, key) : getProperty(token.data, key) || null;
+        if (mode === ACTIVE_EFFECT_MODES.UPGRADE) {
+            if ((typeof (current) === "number") && (current >= Number(value))) return null;
+        }
+        if (mode === ACTIVE_EFFECT_MODES.DOWNGRADE) {
+            if ((typeof (current) === "number") && (current < Number(value))) return null;
+        }
+        return value;
+    }
+
 }
 
 
 
 Hooks.on('init', ATL.init);
-Hooks.on('ready', ATL.ready);
+Hooks.on('ready', ATL.ready)
+Hooks.on("canvasReady", () => {
+    if (game.settings.get("ATL", "conversion") !== "0.2.0") {
+        performConversion()
+    }
+
+
+    function performConversion() {
+        let presetArray = game.settings.get("ATL", "presets")
+        for (let preset of presetArray) {
+            console.log(`ATL: Updating preset ${preset.name}`)
+            for (const [key, value] of Object.entries(preset)) {
+                if (key === "lightEffect") {
+                    preset.lightAnimation = preset.lightEffect
+                    delete preset.lightEffect
+                }
+                if (key === "lightAngle" && typeof value !== "number") {
+                    preset.lightAngle = parseInt(preset.lightAngle)
+                }
+                if (key === "sightAngle" && typeof value !== "number") {
+                    preset.sightAngle = typeof parseInt(preset.sightAngle) === "number" ? parseInt(preset.sightAngle) : 0;
+                }
+            }
+        }
+        console.log("ATL: Update finished")
+        game.settings.set("ATL", "presets", presetArray)
+        game.settings.set("ATL", "conversion", "0.2.0")
+    }
+
+});
 Hooks.on('getSceneControlButtons', ATL.getSceneControlButtons)
+
+
+

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -403,15 +403,17 @@ class ATL {
             });
         }
     }
-     static async applyEffects(entity, effects) {
+    static async applyEffects(entity, effects) {
+        let link = entity.token.data.actorLink
         let tokenArray = entity.getActiveTokens()
         let overrides = {};
-        const originals = await entity.getFlag("ATL", "originals") || {};
+        const originals = link ? (await entity.getFlag("ATL", "originals") || {}) : (await entity.token.getFlag("ATL", "originals") || {});
+  
 
-        for(let test of effects){
-            for( let change of test.data.changes){
-                if(change.key.includes("flags.ATL.lighting")) { change.key.replace("flags.ATL.lighting", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`)}
-                if(change.key.includes("flags.ATL.size")) { change.key.replace("flags.ATL.size", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`)}
+        for (let test of effects) {
+            for (let change of test.data.changes) {
+                if (change.key.includes("flags.ATL.lighting")) { change.key = change.key.replace("flags.ATL.lighting", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`) }
+                if (change.key.includes("flags.ATL.size")) { change.key = change.key.replace("flags.ATL.size", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`) }
 
             }
         }
@@ -464,7 +466,8 @@ class ATL {
         }
         //update actor token
         let updatedToken = Object.assign(entity.data.token, overrides)
-        await entity.setFlag("ATL", "originals", originals)
+        if (link) await entity.setFlag("ATL", "originals", originals)
+        else entity.token.setFlag("ATL", "originals", originals)
         await entity.update({ token: updatedToken })
     }
 
@@ -530,7 +533,7 @@ class ATL {
         }
         return value;
     }
-    
+
 }
 
 

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -408,6 +408,14 @@ class ATL {
         let overrides = {};
         const originals = await entity.getFlag("ATL", "originals") || {};
 
+        for(let test of effects){
+            for( let change of test.data.changes){
+                if(change.key.includes("flags.ATL.lighting")) { change.key.replace("flags.ATL.lighting", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`)}
+                if(change.key.includes("flags.ATL.size")) { change.key.replace("flags.ATL.size", "ATL"), console.warn(`ATL: ${test.data.label} on actor ${entity.data.name} is out of date, please update to the new schema`)}
+
+            }
+        }
+
         // Organize non-disabled effects by their application priority
         const changes = effects.reduce((changes, e) => {
             if (e.data.disabled) return changes;
@@ -522,7 +530,7 @@ class ATL {
         }
         return value;
     }
-
+    
 }
 
 


### PR DESCRIPTION
This is a large update that fundamentally changes the backend framework of the module. Your current ATL effects will not be changed in function, but you will get warnings to change to the new syntax. This will be slowly phased out over updates. Any ATL flag will now adjust a linked actor Prototype Token to match the data, these will carry between scenes as they should. The `lightEffect` key has been changed to `lightAnimation` any previous `lightEffect` flags will not work and need to be updated immediately. 
closes #26 