### PR TITLE
Add additional properties that must be converted to numeric types

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -655,7 +655,7 @@ class ATL {
     }
 
     static switchType(key, value) {
-        let numeric = ["light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
+        let numeric = ["brightSight", "dimSight", "light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
         let Boolean = ["mirrorX", "mirrorY"]
         if (numeric.includes(key)) return parseFloat(value)
         else if (Boolean.includes(key)) {


### PR DESCRIPTION
Both `brightSight` and `dimSight` values are passed as strings on certain DAE change modes. 

The `switchType` method was seemingly missing these two properties.