### PR TITLE
Manage the false positive given from the 0 number 

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -578,7 +578,22 @@ class ATL {
                 }
             }
             else {
-                let preValue = (overrides[updateKey] ? overrides[updateKey] : getProperty(originals, updateKey)) ? getProperty(originals, updateKey) : getProperty(entity, `data.token.${updateKey}`)  ? getProperty(entity, `data.token.${updateKey}`) : null;
+                let preValueOriginal = (overrides[updateKey] ? overrides[updateKey] : getProperty(originals, updateKey));
+                let preValue = null;
+                // Manage the false positive given from the 0 number value is detected like a 'false' from standard ecmascript
+                // and set the 'null' value instead the '0' value
+                if(typeof preValueOriginal === 'number' || !isNaN(preValueOriginal)) {
+                    preValue = getProperty(originals, updateKey) != null && getProperty(originals, updateKey) != undefined
+                        ? getProperty(originals, updateKey) 
+                        : getProperty(entity, `data.token.${updateKey}`);
+                    if(preValue != null && preValue != undefined && isNaN(preValue)){
+                        preValue = Number(preValue);
+                    }
+                } else {
+                    preValue = preValueOriginal 
+                        ? getProperty(originals, updateKey) 
+                        : getProperty(entity, `data.token.${updateKey}`)  ? getProperty(entity, `data.token.${updateKey}`) : null;
+                }
                 let result = ATL.apply(entity, change, originals, preValue);
                 if (change.key === "ATL.alpha") result = result * result
                 if (result !== null) {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -648,6 +648,13 @@ class ATL {
         let tokenArray = []
         if (!link) tokenArray = [entity.token?.object]
         else tokenArray = entity.getActiveTokens()
+
+        // Little trick forn when some token is selected
+        // instead get all active tokens
+        if(canvas.tokens.controlled?.length > 0){
+            tokenArray = canvas.tokens.controlled;
+        }
+
         if (tokenArray === []) return;
         let overrides = {};
         const originals = link 

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -638,11 +638,30 @@ class ATL {
 
         if (changes.length < 1) overrides = originals
 
-
+        let currentTokens = canvas.tokens.placeables.filter((t) => t.data.actorId == entity.id);
         // Expand the set of final overrides
         for (let eachToken of tokenArray) {
-            let updates = duplicate(originals)
-            Object.assign(updates, overrides)
+            // Strange bug fix when update the active effects the value of sight and vision
+            // are recovered from the prototype token not the actual token that reset the token
+            // with the original value from the prototype token
+            let tokenOriginals = duplicate(originals);
+            if(currentTokens.filter((t) => t.id == eachToken.id).length > 0){
+                tokenOriginals.light = eachToken.data.light;
+                tokenOriginals.dimSight = eachToken.data.dimSight;
+                tokenOriginals.brightSight = eachToken.data.brightSight;
+                tokenOriginals.sightAngle = eachToken.data.sightAngle;
+                tokenOriginals.name = eachToken.data.name;
+                tokenOriginals.height = eachToken.data.height;
+                tokenOriginals.width = eachToken.data.width;
+                tokenOriginals.scale = eachToken.data.scale;
+                //tokenOriginals.id = eachToken.data.id;
+            }
+            let updates = duplicate(tokenOriginals)
+            if (changes.length < 1) {
+                Object.assign(updates, tokenOriginals);
+            } else {
+                Object.assign(updates, overrides);
+            }
             await eachToken.document.update(updates)
         }
         //update actor token
@@ -670,7 +689,7 @@ class ATL {
     }
 
     static switchType(key, value) {
-        let numeric = ["light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
+        let numeric = ["brightSight", "dimSight", "light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
         let Boolean = ["mirrorX", "mirrorY"]
         if (numeric.includes(key)) return parseFloat(value)
         else if (Boolean.includes(key)) {

--- a/src/updateManager.js
+++ b/src/updateManager.js
@@ -61,7 +61,7 @@ export class ATLUpdate {
                 if (change.key.includes("ATL")) {
                     changeFound = true;
                     updates.push(this.v9UpdateEffect(duplicate(change)))
-                } 
+                }
                 else updates.push(change);
             }
             if (changeFound) {
@@ -79,7 +79,8 @@ export class ATLUpdate {
             case "ATL.brightSight":
             case "ATL.dimSight":
             case "ATL.height":
-            case "ATl.img":
+            case "ATl.img": // this is a typo but we leave here for retrocompatibility
+            case "ATL.img":
             case "ATL.mirrorX":
             case "ATL.mirrorY":
             case "ATL.rotation":


### PR DESCRIPTION
This is connected to this issue https://github.com/kandashi/Active-Token-Lighting/pull/91/files because i encounter the same issue with the property `brightSight`, but i think this check is something to add too.

Manage the false positive given from the 0 number value because is detected like a 'false' from standard ecmascript and wrongly set the 'null' value instead the '0' value, so i there is some other property number it will be correctly converted ?