### PR TITLE
New proto rework

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -116,9 +116,19 @@ class ATL {
             if (!gm) return;
             let linkedTokens = canvas.tokens.placeables.filter(t => !t.data.link)
             for( let token of linkedTokens){
-                let ATLeffects = token.actor.effects.filter(entity => !!entity.data.changes.find(effect => effect.key.includes("ATL")))
+                let ATLeffects = token.actor.data.effects.filter(entity => !!entity.data.changes.find(effect => effect.key.includes("ATL")))
                 if (ATLeffects.length > 0) ATL.applyEffects(token.actor, ATLeffects)
             }
+        })
+
+        Hooks.on("updateItem", (item, update) => {
+            if (!gm || game.system.id !== "dnd5e" || !item.parent) return;
+            if("equipped" in update.data || "attunement" in update.data) {
+                let actor = item.parent
+                let ATLeffects = actor.effects.filter(entity => !!entity.data.changes.find(effect => effect.key.includes("ATL")))
+                if (ATLeffects.length > 0) ATL.applyEffects(actor, ATLeffects)
+            }
+            
         })
 
         if (!gm) return;
@@ -565,7 +575,7 @@ class ATL {
 
         // Organize non-disabled effects by their application priority
         const changes = effects.reduce((changes, e) => {
-            if (e.data.disabled) return changes;
+            if (e.data.disabled || e.isSuppressed ) return changes;
             return changes.concat(e.data.changes.map(c => {
                 c = duplicate(c);
                 c.effect = e;
@@ -669,7 +679,7 @@ class ATL {
 
     static switchType(key, value) {
         let numeric = ["brightSight", "dimSight", "light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
-        let Boolean = ["mirrorX", "mirrorY"]
+        let Boolean = ["mirrorX", "mirrorY", "light.gradual", "vision"]
         if (numeric.includes(key)) return parseFloat(value)
         else if (Boolean.includes(key)) {
             if (value === "true") return true

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -404,7 +404,7 @@ class ATL {
                     label: "Add Preset",
                     icon: `<i class="fas fa-check"></i>`,
                     callback: async (html) => {
-                        let id = html.find("#name")[0].name || randomID()
+                        let id = html.find("#name")[0].value || randomID()
                         let name = html.find("#name")[0].value
                         let height = await ATL.checkString(html.find("#height")[0].value)
                         let width = await ATL.checkString(html.find("#width")[0].value)
@@ -647,6 +647,9 @@ class ATL {
                                 .replace(/@colon@/g, ':');
 
                             resultTmp = JSON.parse(fixedJSON);
+                            for (const [key, value] of Object.entries(resultTmp)) {
+                                resultTmp[key] = ATL.switchType(key, value)
+                            }
                         }
                     }
                     overrides[updateKey] = resultTmp ? resultTmp : result;
@@ -656,6 +659,7 @@ class ATL {
         if (changes.length < 1) overrides = originals
         let updates = duplicate(originals)
         mergeObject(updates, overrides)
+        if(entity.data.token.randomImg) delete updates.img
         let updateMap = tokenArray.map(t => mergeObject({_id: t.id}, updates))
         await canvas.scene.updateEmbeddedDocuments("Token", updateMap)
     }
@@ -678,7 +682,7 @@ class ATL {
     }
 
     static switchType(key, value) {
-        let numeric = ["brightSight", "dimSight", "light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation"]
+        let numeric = ["brightSight", "dimSight", "light.dim", "light.bright", "dim", "bright", "scale", "height", "width", "light.angle", "light.alpha", "rotation", "speed", "intensity"]
         let Boolean = ["mirrorX", "mirrorY", "light.gradual", "vision"]
         if (numeric.includes(key)) return parseFloat(value)
         else if (Boolean.includes(key)) {

--- a/src/updateManager.js
+++ b/src/updateManager.js
@@ -206,5 +206,18 @@ export class ATLUpdate {
         return newData
     }
 
+    static async flagBuster(actor){
+        console.warn(`Updating ${actor.name}`)
+        let flag = actor.getFlag("ATL", "originals")
+        if(!flag) return ui.notifications.notify(`No Flag for ${actor.name}`)
+        let updates = mergeObject(actor.data.token, flag, {inplace: false})
+        await actor.update({token : updates})
+    }
+
+    static async massFlagUpdate(){
+        for(let actor of game.actors){
+            await this.flagBuster(actor)
+        }
+    }
 }
 


### PR DESCRIPTION
New Update: key point is that you must run `ATLUpdate.massFlagUpdate()` as a script macro/command when you load in a new world (otherwise you'll have to manually update some prototype tokens)

This will update in-world actors/tokens but not compendium actors. You can use `ATLUpdate.flagBuster(actor)` to individually update actors