### PR TITLE
Add allowControlWithoutGm setting

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -105,7 +105,7 @@ class ATL {
     static async ready() {
         async function getAllowed () {
             if (game.user.isGM) return true;
-            const gm = !!game.users.find((u) => u.isGM && u.active);
+            const gm = game.users.some((u) => u.isGM && u.active);
             if (gm) return true;
             const allowControlWithoutGm = await game.settings.get("ATL", "allowControlWithoutGm");
             const userRole = game.user.role;


### PR DESCRIPTION
- Add allowControlWithoutGm setting to allow chosen user roles to control ATL effects while the GM is not present.
- Add info notification to advise user when ATL effects are disabled.