### PR TITLE
fix #127 Change implementation to save original values instead of using the prototype token

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -403,7 +403,11 @@ class ATL {
                         if (updateKey === "sight.visionMode") {
                             // also update visionMode defaults
                             const visionDefaults = CONFIG.Canvas.visionModes[result]?.vision?.defaults || {};
-                            for (let [k, v] of Object.entries(visionDefaults)) overrides[`sight.${k}`] = v;
+                            for (let [k, v] of Object.entries(visionDefaults)) {
+                                const key = `sight.${k}`;
+                                const preValue = getProperty(originals, key);
+                                applyOverride(key, v, preValue);
+                            };
                         }
                         applyOverride(updateKey, resultTmp ? resultTmp : result, preValue);
                     }

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -293,6 +293,12 @@ class ATL {
         }, []);
         changes.sort((a, b) => a.priority - b.priority);
 
+        // helper function to apply to overrides and originalDelta
+        const applyOverride = (key, value, preValue) => {
+            overrides[key] = value;
+            if (!hasProperty(originalDelta, key)) originalDelta[key] = preValue;
+        };
+
         for (const token of tokenArray) {
             let originalDelta = token.document.flags.ATL?.originals || {};
             originalDelta = flattenObject(originalDelta);
@@ -395,8 +401,7 @@ class ATL {
                             const visionDefaults = CONFIG.Canvas.visionModes[result]?.vision?.defaults || {};
                             for (let [k, v] of Object.entries(visionDefaults)) overrides[`sight.${k}`] = v;
                         }
-                        overrides[updateKey] = resultTmp ? resultTmp : result;
-                        if (!hasProperty(originalDelta, updateKey)) originalDelta[updateKey] = preValue;
+                        applyOverride(updateKey, resultTmp ? resultTmp : result, preValue);
                     }
                 }
             }

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -396,7 +396,7 @@ class ATL {
                             for (let [k, v] of Object.entries(visionDefaults)) overrides[`sight.${k}`] = v;
                         }
                         overrides[updateKey] = resultTmp ? resultTmp : result;
-                        if (!Object.hasOwn(originalDelta, updateKey)) originalDelta[updateKey] = preValue;
+                        if (!hasProperty(originalDelta, updateKey)) originalDelta[updateKey] = preValue;
                     }
                 }
             }
@@ -412,15 +412,12 @@ class ATL {
                 overrides[key] = null;
             };
             for (const [key, value] of Object.entries(originalDelta)) {
-                if (!Object.hasOwn(overrides, key)) {
+                if (!hasProperty(overrides, key)) {
                     overrides[key] = value;
                     delete overrides[`flags.ATL.originals.${key}`];
                     removeDelta(key);
                 }
             }
-            // add originals flag to the update
-            /* if (isEmpty(originalDelta)) overrides["flags.ATL.-=originals"] = null;
-            else overrides["flags.ATL.originals"] = originalDelta; */
             // update the token document
             console.log("ATE | Going to update token", token.document.id, overrides);
             await token.document.update(overrides);

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -343,7 +343,7 @@ class ATL {
                         const [_, id, key] = parts;
                         const detectionModes =
                             getProperty(overrides, "detectionModes") ||
-                            getProperty(originals, "detectionModes") ||
+                            duplicate(getProperty(originals, "detectionModes")) ||
                             [];                    
                         // find the existing one or create a new one
                         let dm = detectionModes.find(dm => dm.id === id);
@@ -358,7 +358,8 @@ class ATL {
                         // update
                         if (result !== null) {
                             dm[key] = result;
-                            overrides.detectionModes = detectionModes;
+                            const preValue = getProperty(originals, "detectionModes") || [];
+                            applyOverride("detectionModes", detectionModes, preValue);
                         }
                     }
                 } else {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -293,17 +293,17 @@ class ATL {
         }, []);
         changes.sort((a, b) => a.priority - b.priority);
 
-        // helper function to apply to overrides and originalDelta
-        const applyOverride = (key, value, preValue) => {
-            overrides[key] = value;
-            if (!hasProperty(originalDelta, key)) originalDelta[key] = preValue;
-        };
-
         for (const token of tokenArray) {
             let originalDelta = token.document.flags.ATL?.originals || {};
             originalDelta = flattenObject(originalDelta);
             const originals = mergeObject(token.document.toObject(), originalDelta);
             let overrides = {};
+
+            // helper function to apply to overrides and originalDelta
+            const applyOverride = (key, value, preValue) => {
+                overrides[key] = value;
+                if (!(key in originalDelta)) originalDelta[key] = preValue;
+            };
 
             // Apply all changes
             for (let change of changes) {
@@ -417,7 +417,7 @@ class ATL {
                 overrides[key] = null;
             };
             for (const [key, value] of Object.entries(originalDelta)) {
-                if (!hasProperty(overrides, key)) {
+                if (!(key in overrides)) {
                     overrides[key] = value;
                     delete overrides[`flags.ATL.originals.${key}`];
                     removeDelta(key);

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -295,14 +295,13 @@ class ATL {
 
         for (const token of tokenArray) {
             let originalDelta = token.document.flags.ATL?.originals || {};
-            originalDelta = flattenObject(originalDelta);
             const originals = mergeObject(token.document.toObject(), originalDelta);
             let overrides = {};
 
             // helper function to apply to overrides and originalDelta
             const applyOverride = (key, value, preValue) => {
-                overrides[key] = value;
-                if (!(key in originalDelta)) originalDelta[key] = preValue;
+                setProperty(overrides, key, value);
+                if (!hasProperty(originalDelta, key)) setProperty(originalDelta, key, preValue);
             };
 
             // Apply all changes
@@ -416,7 +415,7 @@ class ATL {
                 key = ["flags", "ATL", "originals", ...head, tail].join(".");
                 overrides[key] = null;
             };
-            for (const [key, value] of Object.entries(originalDelta)) {
+            for (const [key, value] of Object.entries(flattenObject(originalDelta))) {
                 if (!(key in overrides)) {
                     overrides[key] = value;
                     delete overrides[`flags.ATL.originals.${key}`];

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -414,9 +414,6 @@ class ATL {
                 }
             }
 
-            console.log("ATE | overrides", JSON.stringify(overrides));
-            console.log("ATE | originalDelta", JSON.stringify(originalDelta));
-
             // add originals flag to the update
             overrides["flags.ATL.originals"] = originalDelta;
             overrides = flattenObject(overrides);

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -143,7 +143,6 @@ class ATL {
             const totalEffects = effect.parent.effects.contents.filter(i => !i.disabled)
             let ATLeffects = totalEffects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
             if (ATLeffects.length > 0) ATL.applyEffects(effect.parent, ATLeffects)
-            //ATL.applyEffect(effect.parent, effect);
         })
 
         Hooks.on("deleteActiveEffect", async (effect, options) => {
@@ -273,51 +272,6 @@ class ATL {
             });
         }
     }
-
-    static async applyEffect(document, effect) {
-        // only react to AE changes on actors
-        if (document.documentName !== "Actor") return;
-        // only react to "enabled" AEs
-        if (effect.disabled || effect.isSuppressed) return;
-        
-        // TODO order changes by priority
-        const changes = effect.changes;
-
-        const tokens = document.getActiveTokens();
-        for (const token of tokens) {
-            const originals = token.document.flags.ATL?.originals || {};
-            const originalData = mergeObject(token.document.toObject(), originals);
-            const overrides = {};
-
-            for (const change of changes) {
-                if (!change.key.startsWith("ATL.")) continue;
-
-                const key = change.key.slice(4);
-                
-                // TODO special handling
-
-                const preValue = getProperty(overrides, key) || getProperty(originalData, key);
-                const result = ATL.apply(document, change, originalData, preValue);
-                if (result !== null) {
-                    // TODO special handling
-                    overrides[key] = result;
-
-                    // if we haven't save the original value, save it now
-                    if (!Object.hasOwn(originals, key))
-                        originals[key] = preValue;
-                }
-            }
-
-            // update token if there are updates
-            if (overrides !== {}) {
-                // include originals flag in update
-                overrides["flags.ATL.originals"] = originals;
-                console.log("ATE | Going to update token with", overrides);
-                token.document.update(overrides);
-            }
-        }
-    }
-
     static async applyEffects(entity, effects) {
         if (entity.documentName !== "Actor") return;
         let link = getProperty(entity, "prototypeToken.actorLink")


### PR DESCRIPTION
The current implementation takes the prototype token and then applies all the active effects on top of that. That means any other changes to the token before applying AEs, whether manually or from another module like TVA, are overwritten. Same goes for changes when you then turn the AEs off, they'll be reverted back to the prototype token.

Older versions of ATL/ATE used to change just the things the active effects touched and saved the original values so they could be reverted with the active effect was removed. There were some problems with that implementation which was the reason for the switch to use the prototype token. I've tried to avoid those same pitfalls in two ways:

1. The original values are saved to the Token instead of the Actor. This mainly caused issues for linked tokens. Although the active effects are the same, the tokens could be manually changed on different scenes and cause some issues.
2. The original values were never removed. This caused issues when resetting the token back to its original settings from when they were first captured as opposed to what the current token's original settings were. This implementation removes the original settings when they're restored. It's not the full mutation stack like Warp Gate tracks but it should work for ATE's case