### PR TITLE
v11 new transferral and swade compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Works very well alongside DAE for equip-toggle effects (Goggles of Night for exa
 
 Most game systems work out-of-the-box, including those using the new active effect transferral mode introduced in Foundry v11. There is, hoever, some code for specific systems to improve compatibility:
 
-- D&D 5e: Active effects on items only apply when equipped and attuned (if applicable), so there's special handling when those are changed (e.g. unequipping an item with an effect will turn off the effect)
-- Warhammer Fantasy Roleplay 4e: same as above with equipped items
-- Savage Worlds Adventure Edition: same as above with equippable items
+- D&D 5e (dnd5e): Active effects on items only apply when equipped and attuned (if applicable), so there's special handling when those are changed (e.g. unequipping an item with an effect will turn off the effect)
+- Warhammer Fantasy Roleplay 4e (wfrp4e): same as above with equipped items
+- Savage Worlds Adventure Edition (swade): same as above with equippable items
 
 ## Premade Items
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ There are 3 preset values for torch, lantern and candle. Use `ATL.preset` and va
 
 Works very well alongside DAE for equip-toggle effects (Goggles of Night for example) or with Midi QoL for consumables (like torches)
 
+## System Compatibility
+
+Most game systems work out-of-the-box, including those using the new active effect transferral mode introduced in Foundry v11. There is, hoever, some code for specific systems to improve compatibility:
+
+- D&D 5e: Active effects on items only apply when equipped and attuned (if applicable), so there's special handling when those are changed (e.g. unequipping an item with an effect will turn off the effect)
+- Warhammer Fantasy Roleplay 4e: same as above with equipped items
+- Savage Worlds Adventure Edition: same as above with equippable items
+
 ## Premade Items
 
  These are made and (and only compatible with) the dnd5e system, but the syntax will apply across all systems.

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -87,9 +87,15 @@ class ATL {
         
 
     }
+
+    static newTransferral() {
+        return game.release.generation >= 11 && !CONFIG.ActiveEffect.legacyTransferral;
+    }
+
     static async ready() {
         const getEffects = (actor) => {
-            if (game.system.id === "wfrp4e") return actor?.actorEffects;
+            if (ATL.newTransferral()) return actor?.appliedEffects;
+            else if (game.system.id === "wfrp4e") return actor?.actorEffects;
             return actor?.effects;
         };
 

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -120,10 +120,19 @@ class ATL {
         })
 
         Hooks.on("createActiveEffect", async (effect, options, userId) => {
-            if (game.userId !== userId || !(effect.parent instanceof Actor)) return;
-            if (!effect.changes?.find(effect => effect.key.includes("ATL"))) return;
-            let ATLeffects = getEffects(effect.parent)
-            if (ATLeffects.length > 0) ATL.applyEffects(effect.parent, ATLeffects)
+            // same user and effect is active
+            if (game.userId !== userId || effect.disabled || effect.isSuppressed) return;
+            // check that the effect is on an actor or an embedded item (for new transferral)
+            let actor;
+            if (effect.parent instanceof Actor) actor = effect.parent;
+            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+                actor = effect.parent.parent;
+            else return;
+            // there's at least one ATL-related effect
+            if (!effect.changes?.some(c => c.key.startsWith("ATL."))) return;
+            // apply the effects
+            let ATLeffects = getEffects(actor);
+            ATL.applyEffects(actor, ATLeffects);
         })
 
         Hooks.on("deleteActiveEffect", async (effect, options, userId) => {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -136,10 +136,19 @@ class ATL {
         })
 
         Hooks.on("deleteActiveEffect", async (effect, options, userId) => {
-            if (game.userId !== userId || !(effect.parent instanceof Actor)) return;
-            if (!effect.changes?.find(effect => effect.key.includes("ATL"))) return;
-            let ATLeffects = getEffects(effect.parent)
-            ATL.applyEffects(effect.parent, ATLeffects)
+            // same user and effect is active
+            if (game.userId !== userId || effect.disabled || effect.isSuppressed) return;
+            // check that the effect is on an actor or an embedded item (for new transferral)
+            let actor;
+            if (effect.parent instanceof Actor) actor = effect.parent;
+            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+                actor = effect.parent.parent;
+            else return;
+             // there's at least one ATL-related effect
+             if (!effect.changes?.some(c => c.key.startsWith("ATL."))) return;
+             // apply the effects
+             let ATLeffects = getEffects(actor);
+             ATL.applyEffects(actor, ATLeffects);
         })
 
         Hooks.on("createToken", (doc, options, userId) => {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -114,8 +114,6 @@ class ATL {
             else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
                 actor = effect.parent.parent;
             else return;
-            // there's at least one ATL-related effect
-            if (!effect.changes?.some(effect => effect.key.startsWith("ATL."))) return;
             // apply the effects
             let ATLeffects = getEffects(actor);
             ATL.applyEffects(actor, ATLeffects);

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -88,16 +88,13 @@ class ATL {
 
     }
 
-    static newTransferral() {
-        return game.release.generation >= 11 && !CONFIG.ActiveEffect.legacyTransferral;
-    }
-
     static async ready() {
+        const newTransferral = game.release.generation >= 11 && !CONFIG.ActiveEffect.legacyTransferral;
         const getEffects = (actor) => {
             if (!actor) return [];
             // get the "active" effects on the actor
             let effects;
-            if (ATL.newTransferral()) effects = actor.appliedEffects;
+            if (newTransferral) effects = actor.appliedEffects;
             else if (game.system.id === "wfrp4e")
               effects = actor.actorEffects.filter((e) => !e.disabled && !e.isSuppressed);
             else effects = actor.effects.filter((e) => !e.disabled && !e.isSuppressed);
@@ -111,7 +108,7 @@ class ATL {
             // check that the effect is on an actor or an embedded item (for new transferral)
             let actor;
             if (effect.parent instanceof Actor) actor = effect.parent;
-            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+            else if (newTransferral && effect.parent?.parent instanceof Actor)
                 actor = effect.parent.parent;
             else return;
             // apply the effects
@@ -125,7 +122,7 @@ class ATL {
             // check that the effect is on an actor or an embedded item (for new transferral)
             let actor;
             if (effect.parent instanceof Actor) actor = effect.parent;
-            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+            else if (newTransferral && effect.parent?.parent instanceof Actor)
                 actor = effect.parent.parent;
             else return;
             // there's at least one ATL-related effect
@@ -141,7 +138,7 @@ class ATL {
             // check that the effect is on an actor or an embedded item (for new transferral)
             let actor;
             if (effect.parent instanceof Actor) actor = effect.parent;
-            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+            else if (newTransferral && effect.parent?.parent instanceof Actor)
                 actor = effect.parent.parent;
             else return;
             // there's at least one ATL-related effect
@@ -179,7 +176,7 @@ class ATL {
         })
 
         // only register these hooks for v11's new transferral mode
-        if (ATL.newTransferral()) {
+        if (newTransferral) {
             const createDeleteItem = (item, options, userId) => {
                 // same user and it's an item on an actor
                 if (game.userId !== userId || !(item.parent instanceof Actor)) return;

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -149,6 +149,21 @@ class ATL {
             }
         })
 
+        // only register these hooks for v11's new transferral mode
+        if (ATL.newTransferral()) {
+            const createDeleteItem = (item, options, userId) => {
+                // same user and it's an item on an actor
+                if (game.userId !== userId || !(item.parent instanceof Actor)) return;
+                // there's at least one ATL-related effect
+                if (!item.effects.some(e => e.changes.some(c => c.key.startsWith("ATL.")))) return;
+                // apply the effects
+                const actor = item.parent;
+                ATL.applyEffects(actor, actor.appliedEffects);
+            };
+            Hooks.on("createItem", createDeleteItem);
+            Hooks.on("deleteItem", createDeleteItem);
+        }
+
         const firstGM = game.users?.find(u => u.isGM && u.active);
         if (game.userId !== firstGM?.id) return;
         let linkedTokens = canvas.tokens.placeables.filter(t => !t.document.link)

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -102,7 +102,7 @@ class ATL {
         Hooks.on("updateActiveEffect", async (effect, change, options, userId) => {
             if (game.userId !== userId || !(effect.parent instanceof Actor)) return;
             if (!effect.changes?.find(effect => effect.key.includes("ATL"))) return;
-            let totalEffects = getEffects(effect.parent).contents.filter(i => !i.disabled)
+            let totalEffects = getEffects(effect.parent).filter(i => !i.disabled)
             let ATLeffects = totalEffects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
             if (effect.disabled) ATLeffects.push(effect)
             ATL.applyEffects(effect.parent, ATLeffects)
@@ -111,7 +111,7 @@ class ATL {
         Hooks.on("createActiveEffect", async (effect, options, userId) => {
             if (game.userId !== userId || !(effect.parent instanceof Actor)) return;
             if (!effect.changes?.find(effect => effect.key.includes("ATL"))) return;
-            const totalEffects = getEffects(effect.parent).contents.filter(i => !i.disabled)
+            const totalEffects = getEffects(effect.parent).filter(i => !i.disabled)
             let ATLeffects = totalEffects.filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
             if (ATLeffects.length > 0) ATL.applyEffects(effect.parent, ATLeffects)
         })

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -106,10 +106,19 @@ class ATL {
         };
 
         Hooks.on("updateActiveEffect", async (effect, change, options, userId) => {
-            if (game.userId !== userId || !(effect.parent instanceof Actor)) return;
-            if (!effect.changes?.find(effect => effect.key.includes("ATL"))) return;
-            let ATLeffects = getEffects(effect.parent)
-            ATL.applyEffects(effect.parent, ATLeffects)
+            // same user
+            if (game.userId !== userId) return;
+            // check that the effect is on an actor or an embedded item (for new transferral)
+            let actor;
+            if (effect.parent instanceof Actor) actor = effect.parent;
+            else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
+                actor = effect.parent.parent;
+            else return;
+            // there's at least one ATL-related effect
+            if (!effect.changes?.some(effect => effect.key.startsWith("ATL."))) return;
+            // apply the effects
+            let ATLeffects = getEffects(actor);
+            ATL.applyEffects(actor, ATLeffects);
         })
 
         Hooks.on("createActiveEffect", async (effect, options, userId) => {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -144,11 +144,11 @@ class ATL {
             else if (ATL.newTransferral() && effect.parent?.parent instanceof Actor)
                 actor = effect.parent.parent;
             else return;
-             // there's at least one ATL-related effect
-             if (!effect.changes?.some(c => c.key.startsWith("ATL."))) return;
-             // apply the effects
-             let ATLeffects = getEffects(actor);
-             ATL.applyEffects(actor, ATLeffects);
+            // there's at least one ATL-related effect
+            if (!effect.changes?.some(c => c.key.startsWith("ATL."))) return;
+            // apply the effects
+            let ATLeffects = getEffects(actor);
+            ATL.applyEffects(actor, ATLeffects);
         })
 
         Hooks.on("createToken", (doc, options, userId) => {

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -142,7 +142,8 @@ class ATL {
         Hooks.on("updateItem", (item, change, options, userId) => {
             if (game.userId !== userId || !item.parent) return;
             if ((game.system.id === "dnd5e" && (hasProperty(change, "system.equipped") || hasProperty(change, "system.attunement")))
-                || (game.system.id === "wfrp4e" && hasProperty(change, "system.worn.value"))) {
+                || (game.system.id === "wfrp4e" && hasProperty(change, "system.worn.value"))
+                || (game.system.id === "swade" && hasProperty(change, "system.equipStatus"))) {
                 let actor = item.parent
                 let ATLeffects = getEffects(actor).filter(entity => !!entity.changes.find(effect => effect.key.includes("ATL")))
                 ATL.applyEffects(actor, ATLeffects)


### PR DESCRIPTION
Using SWADE as the test case, add compatibility with Foundry v11's new active effect transferral mode: foundryvtt/foundryvtt#8978. Add support for equipping/unequipping items in SWADE like we have for other systems. Document the system compatibility in the readme.