### PR TITLE
Initial v12 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,8 +13,8 @@
   ],
   "version": "0.6.2",
   "compatibility": {
-    "minimum": 10,
-    "verified": 11
+    "minimum": 11,
+    "verified": 12
   },
   "esmodules": ["src/activeLighting.js", "src/updateManager.js"],
   "packs": [

--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -1,6 +1,8 @@
 import { PresetConfig } from "./preset-config.js";
 import { ATLUpdate } from "./updateManager.js";
 
+const { deepClone, duplicate, flattenObject, getProperty, hasProperty, mergeObject, setProperty } = foundry.utils;
+
 class ATL {
 
     static init() {


### PR DESCRIPTION
Raise the minimum version to v11 and verified to v12. Then reference the utility functions by using the `foundry.utils` versions rather than the ones in `globalThis`.