### PR TITLE
fix v12 manifest warnings

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
   "esmodules": ["src/activeLighting.js", "src/updateManager.js"],
   "packs": [
     {
-      "name": "Token Effects Premade",
+      "name": "premade",
       "label": "Token Effects premade",
       "path": "packs/premade.db",
       "system": "dnd5e",
@@ -29,7 +29,5 @@
   "styles": ["./styles/ATL.css"],
   "url": "https://github.com/kandashi/Active-Token-Lighting",
   "manifest": "https://raw.githubusercontent.com/kandashi/Active-Token-Lighting/main/module.json",
-  "download": "https://github.com/kandashi/Active-Token-Lighting/archive/main.zip",
-  "allowBugReporter": true,
-  "bugs": "https://github.com/kandashi/Active-Token-Lighting/issues"
+  "download": "https://github.com/kandashi/Active-Token-Lighting/archive/main.zip"
 }


### PR DESCRIPTION
Fixed the compendium pack name and removed the `allowBugReporter` and `bugs` properties that were there for the now long outdated Bug Reporter module.