### PR TITLE
fix Scene Control Buttons for V13

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -535,6 +535,22 @@ class ATL {
 
 window.ATLUpdate = ATLUpdate
 
-Hooks.on('init', ATL.init);
-Hooks.on('ready', ATL.ready)
-Hooks.on('getSceneControlButtons', ATL.getSceneControlButtons)
+Hooks.on('init', () => {
+    ATL.init();
+    if (game.release.generation >= 13) {
+        Hooks.on('getSceneControlButtons', controls => {    
+            if ( !game.user.isGM ) return;
+                controls.lighting.tools.atlLights= {
+                    name: "atlLights",
+                    title: "ATL Presets",
+                    icon: "fas fa-plus-circle",
+                    onChange: (event, active) => ATL.UpdatePresets(),
+                    button: true
+                };
+        });
+    }
+    else {
+        Hooks.on('getSceneControlButtons', ATL.getSceneControlButtons);
+    }
+});
+Hooks.on('ready', ATL.ready);


### PR DESCRIPTION
Hello,
This PR adapts the Scene Control button to V13. I've also added a backward compatibility feature.

However, in V13, there are still several localization errors in the preset menu, but some of these are already present in V12. It's better to completely refactor the preset menu and switch to V2.

I haven't found any other errors with V13, except for a few "deprecated" ones. (But that would be another PR.)