### PR TITLE
Handle equipped items in Dragonbane

### DIFF
--- a/src/activeLighting.js
+++ b/src/activeLighting.js
@@ -170,6 +170,7 @@ class ATL {
             if (game.userId !== userId || !item.parent) return;
             if ((game.system.id === "dnd5e" && (hasProperty(change, "system.equipped") || hasProperty(change, "system.attunement")))
                 || (game.system.id === "wfrp4e" && hasProperty(change, "system.worn.value"))
+                || (game.system.id === "dragonbane" && hasProperty(change, "system.worn"))
                 || (game.system.id === "swade" && hasProperty(change, "system.equipStatus"))) {
                 let actor = item.parent
                 let ATLeffects = getEffects(actor)


### PR DESCRIPTION
Dragonbane has an "apply only when equipped" setting on effects. This change is required for that setting to work.

Note that custom active effects are currently not supported in Dragonbane, but they will be in Foundry v14. This change has been tested by me, the system developer, on Foundry build 14.354. The change has no effect on Dragonbane before Foundry v14.